### PR TITLE
Module code.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+builds/
+extract/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+extract
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 builds/
+extract/

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const extractDir = path.resolve(__dirname, 'extract');
+const headlessDir = path.join(extractDir, 'headless_shell');
+const pathToNss = path.join(extractDir, 'nss', fs.readFileSync(path.join(extractDir, 'nss', 'latest'), 'utf8').trim());
+
+process.env.LD_LIBRARY_PATH = path.join(pathToNss, 'lib') + ':' + process.env.LD_LIBRARY_PATH,
+process.env.PATH = path.join(pathToNss, 'bin') + ':' + process.env.PATH,
+
+exports.chromePath = headlessDir;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "aws-lambda-chrome",
+  "version": "0.0.0",
+  "description": "A lambda compatible build of headless chrome.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "check": "eslint .",
+    "postinstall": "node postinstall.js"
+  },
+  "archives": {
+    "chromeFileName": "chrome-headless-lambda-linux-62.0.3181.0.tgz",
+    "nssFileName": "nss-2017-08-10-990be4e30bf8.tgz"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:universalbasket/aws-lambda-chrome"
+  },
+  "keywords": [
+    "chrome",
+    "headless",
+    "lambda",
+    "aws"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/universalbasket/aws-lambda-chrome/issues"
+  },
+  "homepage": "https://github.com/universalbasket/aws-lambda-chrome#readme",
+  "devDependencies": {
+    "eslint": "^4.6.1",
+    "eslint-config-ub": "^2.0.0"
+  },
+  "dependencies": {
+    "rimraf": "2.6.2",
+    "tar": "4.0.1"
+  }
+}

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const RAW_PACKAGES_URL = 'https://raw.githubusercontent.com/universalbasket/aws-lambda-chrome/master/builds';
+
+const path = require('path');
+const tar = require('tar');
+const rimraf = require('rimraf');
+const fs = require('fs');
+const http = require(RAW_PACKAGES_URL.startsWith('https') ? 'https' : 'http');
+
+const chromePath = `/chrome/${process.env.npm_package_archives_chromeFileName}`;
+const nssPath = `/nss/${process.env.npm_package_archives_nssFileName}`;
+const extractPath = path.resolve(__dirname, 'extract');
+
+function removeExtractDir() {
+    return new Promise((resolve, reject) => {
+        rimraf(extractPath, err => err ? reject(err) : resolve());
+    });
+}
+
+function makeExtractDir() {
+    return new Promise((resolve, reject) => {
+        fs.mkdir(extractPath, err => err ? reject(err) : resolve());
+    });
+}
+
+function download(path, destination) {
+    return new Promise((resolve, reject) => {
+        const req = http.get(RAW_PACKAGES_URL + path, res => {
+            if (res.statusCode < 200 || res.statusCode > 299) {
+                return reject(new Error(`Unexpected status code from GitHub: ${res.statusCode}`));
+            }
+
+            res.on('error', reject);
+            res.pipe(tar.x({ C: destination }));
+        });
+
+        req.on('end', () => resolve());
+        req.on('error', reject);
+    });
+}
+
+console.log('Downloading compiled chrome components.');
+
+removeExtractDir()
+    .then(() => makeExtractDir())
+    .then(() => Promise.all([
+        download(chromePath, extractPath),
+        download(nssPath, extractPath),
+    ]))
+    .then(() => console.log('Finished downloading chrome components.'))
+    .catch(err => {
+        console.error('Error downloading chrome.', err);
+        process.exit(1);
+    });


### PR DESCRIPTION
This code:
 - Downloads and extracts archives for headless_shell and NSS based upon package config using the `postinstall` npm hook.
 - Provides a module which exports an absolute path to the extracted headless_shell, and paths which must be prepended to `LD_LIBRARY_PATH` and `PATH` in order for chrome to pick up NSS.