### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-chrome",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A lambda compatible build of headless chrome.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Thanks for this great article [link](https://medium.com/the-automator/aws-lambda-chrome-headless-5db989d36040). Could you release new tag `v1.0.1`, so people could download newest chrome from [here](https://github.com/universalbasket/aws-lambda-chrome/tree/master/builds/chrome) by using npm or yarn? :)